### PR TITLE
Ability to modify ticketing options

### DIFF
--- a/src/mt-cart.php
+++ b/src/mt-cart.php
@@ -190,7 +190,7 @@ function mt_invite_login_or_register() {
  */
 function mt_render_types( $types ) {
 	$options   = array_merge( mt_default_settings(), get_option( 'mt_settings' ) );
-	$ticketing = $options['mt_ticketing'];
+	$ticketing = apply_filters("mt_ticketing_availability", $options['mt_ticketing'], $cart);
 	$default   = isset( $options['mt_ticket_type_default'] ) ? $options['mt_ticket_type_default'] : '';
 	$output    = '<p><label for="ticketing_method">' . __( 'Ticket Type', 'my-tickets' ) . '</label> <select name="ticketing_method" id="ticketing_method">';
 	foreach ( $ticketing as $key => $method ) {


### PR DESCRIPTION
I have a case whereby we would offer postal and box office tickets. Because postal tickets would take about 4 or 5 days to get to an attendee, it would be preferable just to disable the postal option but keep the box office option going until the expiry date set in the event. With that in mind, I have added a filter "mt_ticketing_availability" which filters the available ticketing options with a view to modifying it. The filter also accepts the $cart variable so that checks can be made against the cart items and the ticketing amended appropriately.